### PR TITLE
fixes "closure requires explicit 'self.'"

### DIFF
--- a/ios/ExpoDynamicAppIconModule.swift
+++ b/ios/ExpoDynamicAppIconModule.swift
@@ -6,7 +6,7 @@ public class ExpoDynamicAppIconModule: Module {
     Name("ExpoDynamicAppIcon")
 
     Function("setAppIcon") { (name:String) -> String in
-      setAppIconWithoutAlert(name)
+      self.setAppIconWithoutAlert(name)
 
       return name
     }


### PR DESCRIPTION
Before this PR, building this on expo.dev gave the following:

```
› Compiling expo-dynamic-app-icon Pods/ExpoDynamicAppIcon » ExpoDynamicAppIconModule.swift

❌  (node_modules/expo-dynamic-app-icon/ios/ExpoDynamicAppIconModule.swift:9:7)

   7 | 
   8 |     Function("setAppIcon") { (name:String) -> String in
>  9 |       setAppIconWithoutAlert(name)
     |       ^ call to method 'setAppIconWithoutAlert' in closure requires explicit use of 'self' to make capture semantics explicit
  10 | 
  11 |       return name
  12 |     }
```

After this PR the build passes and the extension works as expected.