### PR TITLE
Expo SDK 53 & Android deep link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ add plugins in `app.json`
         {
           "red": { // icon name
             "image": "./assets/icon1.png", // icon path
-            "prerendered": true // for ios UIPrerenderedIcon option
+            "prerendered": true, // for ios UIPrerenderedIcon option
+            "platforms":  ["ios", "android"]  // optional platforms array. defaults to both platforms if emitted
           },
           "gray": {
             "image": "./assets/icon2.png",
-            "prerendered": true
+            "prerendered": true,
+            "platforms":  ["ios"]
           }
         }
       ]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 
@@ -52,20 +52,23 @@ afterEvaluate {
 
 android {
   namespace = "expo.modules.dynamicappicon"
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
     versionCode 1
     versionName "0.1.0"
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,92 +1,41 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'maven-publish'
 
-group = 'expo.modules.dynamicappicon'
-version = '0.1.0'
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 
-buildscript {
-  def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-  if (expoModulesCorePlugin.exists()) {
-    apply from: expoModulesCorePlugin
-    applyKotlinExpoModulesCorePlugin()
-  }
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
 
-  // Simple helper that allows the root project to override versions declared by this library.
-  ext.safeExtGet = { prop, fallback ->
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-  }
-
-  // Ensures backward compatibility
-  ext.getKotlinVersion = {
-    if (ext.has("kotlinVersion")) {
-      ext.kotlinVersion()
-    } else {
-      ext.safeExtGet("kotlinVersion", "1.8.10")
+// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
+// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
+// Most of the time, you may like to manage the Android SDK versions yourself.
+def useManagedAndroidSdkVersions = true
+if (useManagedAndroidSdkVersions) {
+  useDefaultAndroidSdkVersions()
+} else {
+  buildscript {
+    // Simple helper that allows the root project to override versions declared by this library.
+    ext.safeExtGet = { prop, fallback ->
+      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
     }
   }
-
-  repositories {
-    mavenCentral()
-  }
-
-  dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getKotlinVersion()}")
-  }
-}
-
-afterEvaluate {
-  publishing {
-    publications {
-      release(MavenPublication) {
-        from components.release
-      }
-    }
-    repositories {
-      maven {
-        url = mavenLocal().url
-      }
+  project.android {
+    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    defaultConfig {
+      minSdkVersion safeExtGet("minSdkVersion", 21)
+      targetSdkVersion safeExtGet("targetSdkVersion", 34)
     }
   }
 }
 
 android {
   namespace = "expo.modules.dynamicappicon"
-  compileSdkVersion safeExtGet("compileSdkVersion", 33)
-
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.majorVersion
-    }
-  }
-
   defaultConfig {
-    minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 34)
     versionCode 1
     versionName "0.1.0"
   }
   lintOptions {
     abortOnError false
   }
-  publishing {
-    singleVariant("release") {
-      withSourcesJar()
-    }
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
-dependencies {
-  implementation project(':expo-modules-core')
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -86,22 +86,16 @@ const withDynamicIcon: ConfigPlugin<string[] | IconSet | void> = (
   const iOSIcons = findIconsForPlatform(prepped, "ios");
   const iOSIconsLength = Object.keys(iOSIcons).length;
   if (iOSIconsLength > 0) {
-    console.log(`DynamicIcon: Adding ${iOSIconsLength} dynamic iOS icons!`, JSON.stringify(Object.keys(iOSIcons)));
     config = withIconXcodeProject(config, { icons: iOSIcons });
     config = withIconInfoPlist(config, { icons: iOSIcons });
     config = withIconIosImages(config, { icons: iOSIcons });
-  } else {
-    console.log('DynamicIcon: No iOS icons found!');
   }
   const androidIcons = findIconsForPlatform(prepped, "android");
   const androidIconsLength = Object.keys(androidIcons).length;
   if (androidIconsLength > 0) {
-    console.log(`DynamicIcon: Adding ${androidIconsLength} dynamic Android icons!`, JSON.stringify(Object.keys(androidIcons)));
     config = withIconAndroidManifest(config, { icons: androidIcons });
     config = withIconAndroidImages(config, { icons: androidIcons });
-  } else {
-    console.log('DynamicIcon: No Android icons found!');
-  }
+  } 
 
   return config;
 };

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -32,7 +32,9 @@ const androidSize = [162, 108, 216, 324, 432];
 
 const iosFolderName = "DynamicAppIcons";
 const iosSize = 60;
-const iosScales = [2, 3];
+const ipad152Scale = 2.53;
+const ipad167Scale = 2.78;
+const iosScales = [2, 3, ipad152Scale, ipad167Scale];
 
 type IconSet = Record<string, { image: string; prerendered?: boolean }>;
 
@@ -197,9 +199,16 @@ const withIconAndroidImages: ConfigPlugin<Props> = (config, { icons }) => {
 
 // for ios
 function getIconName(name: string, size: number, scale?: number) {
-  const fileName = `${name}-Icon-${size}x${size}`;
+  
+  const fileName = `${name}-Icon-$${size}x${size}`;
 
   if (scale != null) {
+    if(scale == ipad152Scale){
+      return `${fileName}@2x~ipad.png`;
+    }
+    if(scale == ipad167Scale){
+      return `${fileName}@3x~ipad.png`;
+    }
     return `${fileName}@${scale}x.png`;
   }
   return fileName;
@@ -361,7 +370,7 @@ async function createIconsAsync(
       const fileName = path.join(iosFolderName, iconFileName);
       const outputPath = path.join(iosRoot, fileName);
 
-      const scaledSize = scale * iosSize;
+      const scaledSize = Math.ceil(scale * iosSize);
       const { source } = await generateImageAsync(
         {
           projectRoot: config.modRequest.projectRoot,

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -93,7 +93,14 @@ const withIconAndroidManifest: ConfigPlugin<Props> = (config, { icons }) => {
             "android:icon": `@mipmap/${iconName}`,
             "android:targetActivity": ".MainActivity",
           },
-          "intent-filter": [...mainActivity["intent-filter"]],
+          "intent-filter": [...mainActivity["intent-filter"] || [
+            {
+              action: [{ $: { "android:name": "android.intent.action.MAIN" } }],
+              category: [
+                { $: { "android:name": "android.intent.category.LAUNCHER" } },
+              ],
+            },
+          ]]
         })),
       ];
     }

--- a/plugin/src/withDynamicIcon.ts
+++ b/plugin/src/withDynamicIcon.ts
@@ -16,9 +16,8 @@ import path from "path";
 import pbxFile from "xcode/lib/pbxFile";
 
 const {
-  addMetaDataItemToMainApplication,
   getMainApplicationOrThrow,
-  addUsesLibraryItemToMainApplication,
+  getMainActivityOrThrow,
 } = AndroidConfig.Manifest;
 
 const androidFolderPath = ["app", "src", "main", "res"];
@@ -78,6 +77,7 @@ const withDynamicIcon: ConfigPlugin<string[] | IconSet | void> = (
 const withIconAndroidManifest: ConfigPlugin<Props> = (config, { icons }) => {
   return withAndroidManifest(config, (config) => {
     const mainApplication: any = getMainApplicationOrThrow(config.modResults);
+    const mainActivity = getMainActivityOrThrow(config.modResults);
 
     const iconNamePrefix = `${config.android!.package}.MainActivity`;
     const iconNames = Object.keys(icons);
@@ -93,14 +93,7 @@ const withIconAndroidManifest: ConfigPlugin<Props> = (config, { icons }) => {
             "android:icon": `@mipmap/${iconName}`,
             "android:targetActivity": ".MainActivity",
           },
-          "intent-filter": [
-            {
-              action: [{ $: { "android:name": "android.intent.action.MAIN" } }],
-              category: [
-                { $: { "android:name": "android.intent.category.LAUNCHER" } },
-              ],
-            },
-          ],
+          "intent-filter": [...mainActivity["intent-filter"]],
         })),
       ];
     }


### PR DESCRIPTION
Updating android build.gradle to match one of a newly created module, which allows for building with Expo SDK 50.

I'm unsure if any other changes are required, however, I have tested in my own project using SDK 50, and I can confirm it works for me.